### PR TITLE
improve performance a bit

### DIFF
--- a/test/gh-resolve.js
+++ b/test/gh-resolve.js
@@ -1,6 +1,6 @@
 
 var env = process.env;
-var resolve = require('./');
+var resolve = require('../');
 var assert = require('assert');
 var netrc = require('node-netrc');
 var auth = netrc('api.github.com') || {};
@@ -69,6 +69,14 @@ describe('resolve()', function(){
     resolve('sweet/repo@amazing/version', user, tok, function(err, ref){
       assert(err);
       assert(~err.message.indexOf('sweet/repo@amazing/version'));
+      done();
+    });
+  })
+
+  it('should resolve twbs/bootstrap@* quickly', function(done){
+    resolve('twbs/bootstrap@*', user, tok, function(err, ref){
+      if (err) return done(err);
+      assert(/[\d.]{3}/.test(ref.name));
       done();
     });
   })

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--reporter spec
+--timeout 10s


### PR DESCRIPTION
- only paginate if we haven't found anything yet
- for `*`, get `tags` first, if nothing get `heads`. getting both tags and heads was incredibly slow for big projects like bootstrap.

Performance difference when resolving `twbs/bootstrap@*`:

```
before: 14290ms
after: 1309ms
```

All the other tests don't really show much performance difference, probably because they're relatively small in comparison.

```
before: 

  resolve()
    ✓ should resolve a semver version to gh ref (1535ms)
    ✓ should sort properly (1614ms)
    ✓ should resolve a branch to gh ref (1217ms)
    ✓ should resolve branches with `/` in them (1867ms)
    ✓ should default to the latest tag when the ref is `*` (2110ms)
    ✓ should use master when there are no tags and ref is `*` (1266ms)
    ✓ should provide better errors for invalid repos (1227ms)

after:

  resolve()
    ✓ should resolve a semver version to gh ref (1884ms)
    ✓ should sort properly (2992ms)
    ✓ should resolve a branch to gh ref (1549ms)
    ✓ should resolve branches with `/` in them (1528ms)
    ✓ should default to the latest tag when the ref is `*` (1944ms)
    ✓ should use master when there are no tags and ref is `*` (3517ms)
    ✓ should provide better errors for invalid repos (1021ms)
    ✓ should resolve twbs/bootstrap@* quickly (1316ms)

```

Note when references `*` for small repos that have no tags, just master, there will be a decrease in performance.
