### PR TITLE
Use GH API directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
-  - "0.12"
-  - "iojs"
+  - '0.10'
+  - '0.11'
+  - '0.12'
+  - iojs
 script: make lint test
 cache:
   directories:
@@ -11,4 +11,4 @@ cache:
 sudo: false
 env:
   global:
-    - secure: WdPVuaRFwTYKNFx7goA36QGwCPDATLT1PUL3XLilZX/AlfjgRICZn7/55WnSk7IJtkexYA4uuXlqIqefWMEACHW0gzwYrQES90wRonLUPYEbUUlfhXJFKWE1XCQRXDUDk1vX+XaIjsH52HcYGDbfauU8sRvrzOq1kPd5R2jWkRE=
+    secure: ZRRIvFc4yGEFUXj/6uu/0aLzKbk4qnkj2yLXBBkGANjT0eAlXgCOsbNVSswXX333NyXqUVOWl6dP1bL/veBN9o0Nou3CYwpbOz/LTFfdvifPA/80M5HhnkxWxQAjxiB4LNmqKDeIqZtHtAwxi0wlSKUwY4WNUy95uT+jyQbLZjk=

--- a/index.js
+++ b/index.js
@@ -107,26 +107,6 @@ function resolve(slug, opts, fn){
 }
 
 /**
- * Get params for github.authenticate()
- *
- * @param {Object} opts
- * @return {Object}
- * @api private
- */
-
-function authenticate(opts) {
-  if (opts.token) {
-    debug('token auth: %s', conceal(opts.token, { start: 6 }));
-    return { type: 'oauth', token: opts.token };
-  } else if (opts.username) {
-    debug('basic auth: %s / %s', opts.username, conceal(opts.password));
-    return { type: 'basic', username: opts.username, password: opts.password };
-  } else {
-    return false;
-  }
-}
-
-/**
  * Create an error
  *
  * @param {String|Error} err

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ function resolve(slug, opts, fn){
   // get version via branch name
   function branch(name) {
     debug('retrieving %s via branch', slug);
+    if (opts.token) debug('using token: %s', conceal(opts.token, { start: 6 }));
 
     gh.branch(parsed.user, parsed.repo, name, function (err, res, data) {
       if (err) return retry(error(err));
@@ -70,6 +71,7 @@ function resolve(slug, opts, fn){
   // get version via tags
   function tags(range) {
     debug('retrieving %s via tags', slug);
+    if (opts.token) debug('using token: %s', conceal(opts.token, { start: 6 }));
 
     gh.tags(parsed.user, parsed.repo, function (err, res, data) {
       if (err) return retry(error(err));

--- a/index.js
+++ b/index.js
@@ -2,30 +2,13 @@
  * Module dependencies.
  */
 
+var conceal = require('conceal');
 var debug = require('debug')('gh-resolve');
-var tokenizer = require('mini-tokenizer');
-var exec = require('child_process').exec;
 var fmt = require('util').format;
 var enqueue = require('enqueue');
+var parse = require('duo-parse');
 var semver = require('semver');
-var satisfies = semver.satisfies;
-var compare = semver.compare;
-var valid = semver.valid;
-var slice = [].slice;
-
-/**
- * Regexps
- */
-
-var rref = /([A-Fa-f0-9]{40})[\t\s]+refs\/(head|tag)s\/([A-Za-z0-9-_\/\.$!#%&\(\)\+=]+)\n/g;
-
-/**
- * Tokenizer
- */
-
-var tokens = tokenizer(rref, function(m) {
-  return { sha: m[1], type: m[2], name: m[3] };
-});
+var GitHub = require('github');
 
 /**
  * Expose `resolve`
@@ -47,15 +30,13 @@ function resolve(slug, opts, fn){
     fn = opts;
     opts = {};
   }
-  var token = opts.token || (
-      opts.password && opts.username
-        ? [opts.username, opts.password].join(':')
-        : ''
-    );
-  var repo = slug.split('@')[0];
-  var ref = slug.split('@')[1];
-  var url = remote(repo, token);
-  var cmd = fmt('git ls-remote --tags --heads %s', url);
+
+  var gh = new GitHub({ version: '3.0.0', debug: false });
+  var auth = authenticate(opts);
+  if (auth) gh.authenticate(auth);
+
+  var parsed = parse(slug);
+  var ref = parsed.ref || '*';
 
   // options
   opts.retries = typeof opts.retries === 'undefined' ? 1 : opts.retries;
@@ -67,14 +48,64 @@ function resolve(slug, opts, fn){
   }
 
   // execute
-  debug('executing: %s', mask(cmd));
-  exec(cmd, function(err, stdout, stderr) {
-    debug('executed: %s', mask(cmd));
-    if (err || stderr) return retry(error(err || stderr));
-    var refs = tokens(stdout).sort(arrange);
-    var tag = satisfy(refs, ref);
-    fn(null, tag);
-  });
+  if (semver.validRange(ref) || semver.valid(ref)) {
+    tags(ref);
+  } else {
+    branch(ref);
+  }
+
+
+  // get version via branch name
+  function branch(name) {
+    debug('retrieving %s via branch %s', slug);
+
+    var msg = {
+      user: parsed.user,
+      repo: parsed.repo,
+      branch: name
+    };
+
+    gh.repos.getBranch(msg, function (err, data) {
+      if (err) return retry(error(JSON.parse(err.message)));
+      if (data && data.meta) rateLimit(data.meta);
+
+      fn(null, {
+        name: data.name,
+        sha: data.commit.sha,
+        type: 'branch'
+      });
+    });
+  }
+
+  // get version via tags
+  function tags(range) {
+    debug('retrieving %s via tags', slug);
+
+    var msg = {
+      user: parsed.user,
+      repo: parsed.repo
+    };
+
+    gh.repos.getTags(msg, function (err, data) {
+      if (err) return retry(error(JSON.parse(err.message)));
+      if (data && data.meta) rateLimit(data.meta);
+      if (!data.length) return branch('master');
+
+      var tags = data.reduce(function (acc, tag) {
+        acc[tag.name] = {
+          name: tag.name,
+          sha: tag.commit.sha,
+          type: 'tag'
+        };
+
+        return acc;
+      }, {});
+
+      var tagNames = Object.keys(tags).filter(function (name) { return !!semver.valid(name); });
+      var tag = semver.maxSatisfying(tagNames, range);
+      fn(null, tags[tag]);
+    });
+  }
 
   // retry
   function retry(err){
@@ -89,83 +120,22 @@ function resolve(slug, opts, fn){
 }
 
 /**
- * Get the remote url
+ * Get params for github.authenticate()
  *
- * @param {String} token (optional)
- * @return {String}
- * @api private
- */
-
-function remote(name, token) {
-  token = token ? token + '@' : '';
-  return fmt('https://%sgithub.com/%s', token, name);
-}
-
-/**
- * Satisfy `version` with `refs`.
- *
- * @param {Array} refs
- * @param {String} version
+ * @param {Object} opts
  * @return {Object}
- * @api privae
- */
-
-function satisfy(refs, version){
-  var master;
-  for (var i = 0; i < refs.length; i++) {
-    var ref = refs[i];
-    if (ref.name === 'master') master = ref;
-    if (equal(ref.name, version)) return ref;
-  }
-  return master;
-}
-
-/**
- * Arrange the refs
- *
- * @param {Object} a
- * @param {Object} b
- * @return {Number}
- * @api public
- */
-
-function arrange(a, b) {
-  var ta = a.type === 'tag';
-  var tb = b.type === 'tag';
-
-  // place valid tags in front
-  if (ta && !tb) return -1;
-  if (tb && !ta) return 1;
-
-  var va = !!valid(a.name);
-  var vb = !!valid(b.name);
-
-  // place valid semver in front
-  // if neither are valid, leave as is
-  if (va && !vb) return -1;
-  if (!va && !vb) return 0;
-  if (vb && !va) return 1;
-
-  // compare the semver
-  if (ta && tb) {
-    return -compare(a.name, b.name, true);
-  }
-}
-
-/**
- * Check if the given `ref` is equal to `version`.
- *
- * @param {String} ref
- * @param {String} version
- * @return {Boolean}
  * @api private
  */
 
-function equal(ref, version){
-  try {
-    return satisfies(ref, version, true) || ref === version;
-  } catch (e) {
-    return ref === version;
+function authenticate(opts) {
+  if (opts.token) {
+    debug('token auth: %s', conceal(opts.token, { start: 6 }));
+    return { type: 'oauth', token: opts.token };
+  } else if (opts.username) {
+    debug('basic auth: %s / %s', opts.username, conceal(opts.password));
+    return { type: 'basic', username: opts.username, password: opts.password };
+  } else {
+    return false;
   }
 }
 
@@ -180,19 +150,21 @@ function equal(ref, version){
 
 function error(err) {
   err = err.message || err;
-  var args = slice.call(arguments, 1);
+  var args = [].slice.call(arguments, 1);
   var msg = fmt.apply(fmt, [err].concat(args));
-  return new Error(mask(msg));
+  return new Error(msg);
 }
 
 /**
- * Mask GitHub token in URL, so it doesn't show up in logs.
+ * Outputs rate-limit information via debug.
  *
- * @param {String} url
- * @return {String}
+ * @param {Object} meta
  * @api private
  */
 
-function mask(url) {
-  return url.replace(/\w+@github.com/g, '<token>@github.com');
+function rateLimit(meta) {
+  var remaining = meta['x-ratelimit-remaining'];
+  var limit = meta['x-ratelimit-limit'];
+  var reset = new Date(meta['x-ratelimit-reset'] * 1000);
+  debug('rate limit status: %d / %d (resets: %s)', remaining, limit, reset);
 }

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function resolve(slug, opts, fn){
     opts = {};
   }
 
-  var gh = new GitHub({ version: '3.0.0', debug: false });
+  var gh = new GitHub({ version: '3.0.0' });
   var auth = authenticate(opts);
   if (auth) gh.authenticate(auth);
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 
 var base = 'https://api.github.com/';
 var path = require('path');

--- a/lib/github.js
+++ b/lib/github.js
@@ -1,0 +1,61 @@
+
+var base = 'https://api.github.com/';
+var path = require('path');
+var request = require('request');
+
+module.exports = function (opts) {
+  var token = opts.token;
+
+  return {
+    tags: tags.bind(null, token),
+    branch: branch.bind(null, token)
+  };
+};
+
+function tags(token, owner, repo, callback) {
+  return request({
+    url: url('repos', owner, repo, 'tags'),
+    qs: { access_token: token },
+    json: true,
+    headers: {
+      'Accept': 'application/vnd.github.quicksilver-preview+json',
+      'User-Agent': 'duo:gh-resolve'
+    },
+    followRedirects: true
+  }, handle(callback));
+}
+
+function branch(token, owner, repo, branch, callback) {
+  return request({
+    url: url('repos', owner, repo, 'branches', branch),
+    qs: { access_token: token },
+    json: true,
+    headers: {
+      'Accept': 'application/vnd.github.quicksilver-preview+json',
+      'User-Agent': 'duo:gh-resolve'
+    },
+    followRedirects: true
+  }, handle(callback));
+}
+
+function url() {
+  var parts = [].slice.call(arguments);
+  return base + path.join.apply(path, parts);
+}
+
+function handle(callback) {
+  return function (err, res, data) {
+    if (err) {
+      callback(err, res);
+    } else if (isError(res.statusCode)) {
+      callback(new Error(data.message));
+    } else {
+      callback(null, res, data);
+    }
+  };
+}
+
+function isError(code) {
+  var type = Math.floor(code / 100);
+  return type === 4 || type === 5;
+}

--- a/lib/github.js
+++ b/lib/github.js
@@ -5,7 +5,7 @@ var path = require('path');
 var request = require('request');
 
 module.exports = function (opts) {
-  var token = opts.token;
+  var token = opts.token || opts.password;
 
   return {
     tags: tags.bind(null, token),

--- a/package.json
+++ b/package.json
@@ -3,8 +3,11 @@
   "version": "3.1.0",
   "repository": "duojs/gh-resolve",
   "dependencies": {
+    "conceal": "^1.0.0",
     "debug": "^1.0.2",
+    "duo-parse": "^0.2.0",
     "enqueue": "0.0.x",
+    "github": "^0.2.4",
     "mini-tokenizer": "^0.1.2",
     "request": "^2.34.0",
     "semver": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "debug": "^1.0.2",
     "duo-parse": "^0.2.0",
     "enqueue": "0.0.x",
-    "github": "^0.2.4",
     "mini-tokenizer": "^0.1.2",
     "request": "^2.34.0",
     "semver": "^2.2.1"

--- a/test/gh-resolve.js
+++ b/test/gh-resolve.js
@@ -1,13 +1,13 @@
+
 /**
  * Module Dependencies
  */
 
-var env = process.env;
 var resolve = require('../');
 var assert = require('assert');
 var netrc = require('node-netrc');
 var auth = netrc('api.github.com') || {};
-var tok = env.GITHUB_PASSWORD || auth.password;
+var tok = process.env.GH_TOKEN || auth.password;
 
 /**
  * Tests

--- a/test/gh-resolve.js
+++ b/test/gh-resolve.js
@@ -15,9 +15,9 @@ var tok = env.GITHUB_PASSWORD || auth.password;
 
 describe('resolve()', function(){
   it('should resolve a semver version to gh ref', function(done){
-    resolve('component/component@0.19.6', function(err, ref){
+    resolve('componentjs/component@0.19.6', { token: tok }, function(err, ref){
       if (err) return done(err);
-      assert.equal(ref.sha, '6d6501d002aef91f1261f6ec98c6ed32046fe46a');
+      assert.equal(ref.sha, 'a15d8d10c4c60429cda4080ffd16f2d408992a6d');
       assert.equal(ref.name, '0.19.6');
       assert.equal(ref.type, 'tag');
       done();
@@ -25,7 +25,7 @@ describe('resolve()', function(){
   });
 
   it('should sort properly', function(done){
-    resolve('component/component@0.19.x', function(err, ref){
+    resolve('componentjs/component@0.19.x', function(err, ref){
       if (err) return done(err);
       assert.equal(ref.name, '0.19.9');
       done();
@@ -33,7 +33,7 @@ describe('resolve()', function(){
   });
 
   it('should resolve a branch to gh ref', function(done){
-    resolve('component/component@master', function(err, ref){
+    resolve('componentjs/component@master', function(err, ref){
       if (err) return done(err);
       assert.equal(ref.name, 'master');
       done();
@@ -75,7 +75,7 @@ describe('resolve()', function(){
   it('should provide better errors for invalid repos', function(done) {
     resolve('sweet/repo@amazing/version', function(err){
       assert(err);
-      assert(err.message.indexOf('Repository not found.') > -1);
+      assert(err.message.indexOf('Not Found') > -1);
       done();
     });
   });
@@ -89,28 +89,9 @@ describe('resolve()', function(){
   });
 
   it('should resolve private repos', function(done) {
-    resolve('component/duo@*', { token: tok }, function(err, ref) {
+    resolve('segmentio/duo', { token: tok }, function(err, ref) {
       if (err) return done(err);
       assert(/[\d.]{3}/.test(ref.name));
-      done();
-    });
-  });
-
-  it('should mask token on error', function(done) {
-    resolve('sweet/repo@amazing/version', { token: tok }, function(err){
-      assert(err);
-      assert.equal(err.message.indexOf(tok), -1);
-      assert(err.message.indexOf('repository \'https://<token>@github.com/sweet/repo/\' not found') > -1);
-      done();
-    });
-  });
-
-  it('should mask password on error', function(done) {
-    var opts = { username: 'someuser', password: 'somepassword' };
-    resolve('decent/repo@good/version', opts, function(err){
-      assert(err);
-      assert.equal(err.message.indexOf('somepassword'), -1);
-      assert(err.message.indexOf('someuser:<token>@github') > -1);
       done();
     });
   });

--- a/test/gh-resolve.js
+++ b/test/gh-resolve.js
@@ -6,8 +6,7 @@
 var resolve = require('../');
 var assert = require('assert');
 var netrc = require('node-netrc');
-var auth = netrc('api.github.com') || {};
-var tok = process.env.GH_TOKEN || auth.password;
+var auth = netrc('api.github.com') || { token: process.env.GH_TOKEN };
 
 /**
  * Tests
@@ -15,7 +14,7 @@ var tok = process.env.GH_TOKEN || auth.password;
 
 describe('resolve()', function(){
   it('should resolve a semver version to gh ref', function(done){
-    resolve('componentjs/component@0.19.6', { token: tok }, function(err, ref){
+    resolve('componentjs/component@0.19.6', auth, function(err, ref){
       if (err) return done(err);
       assert.equal(ref.sha, 'a15d8d10c4c60429cda4080ffd16f2d408992a6d');
       assert.equal(ref.name, '0.19.6');
@@ -25,7 +24,7 @@ describe('resolve()', function(){
   });
 
   it('should sort properly', function(done){
-    resolve('componentjs/component@0.19.x', function(err, ref){
+    resolve('componentjs/component@0.19.x', auth, function(err, ref){
       if (err) return done(err);
       assert.equal(ref.name, '0.19.9');
       done();
@@ -33,7 +32,7 @@ describe('resolve()', function(){
   });
 
   it('should resolve a branch to gh ref', function(done){
-    resolve('componentjs/component@master', function(err, ref){
+    resolve('componentjs/component@master', auth, function(err, ref){
       if (err) return done(err);
       assert.equal(ref.name, 'master');
       done();
@@ -41,7 +40,7 @@ describe('resolve()', function(){
   });
 
   it('should resolve branches with `/` in them', function(done){
-    resolve('cheeriojs/cheerio@refactor/core', function(err, ref){
+    resolve('cheeriojs/cheerio@refactor/core', auth, function(err, ref){
       if (err) return done(err);
       assert.equal(ref.name, 'refactor/core');
       done();
@@ -49,7 +48,7 @@ describe('resolve()', function(){
   });
 
   it('should default to the latest tag when the ref is `*`', function(done){
-    resolve('segmentio/analytics.js@*', function(err, ref){
+    resolve('segmentio/analytics.js@*', auth, function(err, ref){
       if (err) return done(err);
       assert(/[\d.]{3}/.test(ref.name));
       done();
@@ -57,7 +56,7 @@ describe('resolve()', function(){
   });
 
   it('should use master when there are no tags and ref is `*`', function(done) {
-    resolve('matthewmueller/throttle@*', function(err, ref){
+    resolve('matthewmueller/throttle@*', auth, function(err, ref){
       if (err) return done(err);
       assert.equal(ref.name, 'master');
       done();
@@ -65,7 +64,7 @@ describe('resolve()', function(){
   });
 
   it('should use master when there are no tags', function(done){
-    resolve('mnmly/slider', function(err, ref){
+    resolve('mnmly/slider', auth, function(err, ref){
       if (err) return done(err);
       assert.equal(ref.name, 'master');
       done();
@@ -73,7 +72,7 @@ describe('resolve()', function(){
   });
 
   it('should provide better errors for invalid repos', function(done) {
-    resolve('sweet/repo@amazing/version', function(err){
+    resolve('sweet/repo@amazing/version', auth, function(err){
       assert(err);
       assert(err.message.indexOf('Not Found') > -1);
       done();
@@ -81,7 +80,7 @@ describe('resolve()', function(){
   });
 
   it('should resolve twbs/bootstrap@* quickly', function(done){
-    resolve('twbs/bootstrap@*', function(err, ref){
+    resolve('twbs/bootstrap@*', auth, function(err, ref){
       if (err) return done(err);
       assert(/[\d.]{3}/.test(ref.name));
       done();
@@ -89,7 +88,7 @@ describe('resolve()', function(){
   });
 
   it('should resolve renamed repos', function(done) {
-    resolve('segmentio/duo', { token: tok }, function(err, ref) {
+    resolve('segmentio/duo', auth, function(err, ref) {
       if (err) return done(err);
       assert(/[\d.]{3}/.test(ref.name));
       done();
@@ -97,7 +96,7 @@ describe('resolve()', function(){
   });
 
   it('should work on weird semvers', function(done){
-    resolve('chjj/marked@*', function(err, ref){
+    resolve('chjj/marked@*', auth, function(err, ref){
       if (err) return done(err);
       assert(/v[.\d]+/.test(ref.name));
       done();
@@ -105,7 +104,7 @@ describe('resolve()', function(){
   });
 
   it('should resolve multiple non-semantic semvers', function(done) {
-    resolve('alexei/sprintf.js@*', function(err, ref) {
+    resolve('alexei/sprintf.js@*', auth, function(err, ref) {
       if (err) return done(err);
       assert(/[\d.]{3}/.test(ref.name));
       done();
@@ -113,6 +112,6 @@ describe('resolve()', function(){
   });
 
   it('should work on weird branches', function(done) {
-    resolve('cheeriojs/cheerio@refactor/core', done);
+    resolve('cheeriojs/cheerio@refactor/core', auth, done);
   });
 });

--- a/test/gh-resolve.js
+++ b/test/gh-resolve.js
@@ -88,7 +88,7 @@ describe('resolve()', function(){
     });
   });
 
-  it('should resolve private repos', function(done) {
+  it('should resolve renamed repos', function(done) {
     resolve('segmentio/duo', { token: tok }, function(err, ref) {
       if (err) return done(err);
       assert(/[\d.]{3}/.test(ref.name));

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,3 @@
 --reporter spec
 --timeout 10s
+--bail


### PR DESCRIPTION
This changes this lib to use the GitHub API directly instead of using `git ls-remote`, in an attempt at addressing #21. I'm not ready to merge it quite yet, but I would like @duojs/owners to start taking a look.

I'm going to drop this change in place and do some benchmarks on a real-world build. Based on some profiles I ran before, it seemed like spawning child processes was much more expensive than we realized at first.