### PR TITLE
add commit hash support

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -69,6 +69,25 @@ exports.branch = function* (token, options) {
 };
 
 /**
+ * Retrieve the information about a specific commit for a repository.
+ *
+ * @param {String} token
+ * @param {Object} options
+ * @return {Object}
+ */
+
+exports.commit = function* (token, options) {
+  return yield get(token, [
+    'repos',
+    options.owner,
+    options.repo,
+    'git',
+    'commits',
+    options.sha
+  ], options.slug, options.cache);
+};
+
+/**
  * Helper for performing an HTTP GET against the Github API.
  *
  * @param {String} token

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -29,6 +29,17 @@ module.exports = unyield(function* resolve(slug, options) {
   if (!parsed.ref) parsed.ref = '*';
   var ref = parsed.ref;
 
+  if (isSHA(ref)) {
+    debug('%s: resolving via commit SHA', slug, ref);
+    try {
+      return yield commit(token, parsed, cache);
+    } catch (e) {
+      // let resolve errors fall through here, as
+      // an SHA-like branch/tag may exist
+      debug(e);
+    }
+  }
+
   if (semver.validRange(ref) || semver.valid(ref)) {
     debug('%s: resolving via tags matching', slug, ref);
     return yield tags(token, parsed, cache);
@@ -95,6 +106,30 @@ function* branch(token, parsed, cache) {
 }
 
 /**
+ * Resolve a ref via its ref as a commit SHA.
+ *
+ * @param {String} token
+ * @param {Object} parsed
+ * @return {Object}
+ */
+
+function* commit(token, parsed, cache) {
+  var data = yield github.commit(token, {
+    slug: parsed.slug,
+    owner: parsed.user,
+    repo: parsed.repo,
+    sha: parsed.ref,
+    cache: cache
+  });
+
+  return {
+    name: data.sha,
+    sha: data.sha,
+    type: 'commit'
+  };
+}
+
+/**
  * Accept an array of tags and returns the one that matches
  * the input `ref` semver range.
  *
@@ -130,4 +165,18 @@ function indexTags(list) {
 
     return acc;
   }, {});
+}
+
+/**
+ * Loosely check if the given `str` is a commit SHA.
+ *
+ * @param {String} str
+ * @return {Boolean}
+ * @api private
+ */
+
+function isSHA(str){
+  return typeof str === 'string'
+    && str.length === 40
+    && !isNaN(parseInt(str, 16));
 }

--- a/test/gh-resolve.js
+++ b/test/gh-resolve.js
@@ -59,6 +59,13 @@ describe('resolve()', function(){
     assert.equal(ref.name, 'master');
   });
 
+  it('should resolve commit SHAs', function*(){
+    var sha = '8234a9e0c2fea50981b289957fd35dcd59cf39ca';
+    var ref = yield resolve('component/domify@' + sha, auth);
+    assert.equal(ref.type, 'commit');
+    assert.equal(ref.sha, sha);
+  });
+
   it('should resolve twbs/bootstrap@* quickly', function*(){
     var ref = yield resolve('twbs/bootstrap@*', auth);
     assert(/[\d.]{3}/.test(ref.name));


### PR DESCRIPTION
this patch enables us to pin dependencies at as specific commit hash.  unfortunately, the GH api requires a 40-character hash (no "short" hashes), so slugs will resemble `"component/domify@8234a9e0c2fea50981b289957fd35dcd59cf39ca`".  IMO, this is better than losing support entirely though.

closes #25.